### PR TITLE
Fixes for newer versions of numpy and scipy

### DIFF
--- a/src/nets/googlenet.py
+++ b/src/nets/googlenet.py
@@ -30,7 +30,7 @@ class GoogLeNet(BaseModel):
         self._pretrained_dict = None
         if pre_trained_path:
             self._pretrained_dict = np.load(
-                pre_trained_path, encoding='latin1').item()
+                pre_trained_path, encoding='latin1', allow_pickle=True).item()
 
         self.layers = {}
 

--- a/src/utils/dataflow.py
+++ b/src/utils/dataflow.py
@@ -4,7 +4,7 @@
 # Author: Qian Ge <geqian1001@gmail.com>
 
 import os
-import scipy.misc
+import imageio
 import numpy as np
 from datetime import datetime
 
@@ -18,9 +18,9 @@ def load_image(im_path, read_channel=None, pf=identity):
     if read_channel is None:
         im = scipy.misc.imread(im_path)
     elif read_channel == 3:
-        im = scipy.misc.imread(im_path, mode='RGB')
+        im = imageio.imread(im_path, pilmode='RGB')
     else:
-        im = scipy.misc.imread(im_path, flatten=True)
+        im = imageio.imread(im_path, flatten=True)
 
     if len(im.shape) < 3:
         im = pf(im)


### PR DESCRIPTION
I get the following error when running with the current version of numpy:

ValueError: Object arrays cannot be loaded when allow_pickle=False

And the following error when running with the current version of scipy:

AttributeError: module 'scipy.misc' has no attribute 'imread'

This patch fixes both issues.
